### PR TITLE
Introduce CODEOWNERS for easier reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@sailfishos-community/reviewers


### PR DESCRIPTION
As we haven't been too active lately, I don't know who to poke for reviews and I don't know if I come across as bothersome. Thus I would like to have reviewing to be automatic.

This requires that:

- [ ] organization members actually join https://github.com/orgs/sailfishos-community/teams/reviewers
- [x] the team is publicly visible
- [ ] @olpeh grants the team write access to this repository.

