### PR TITLE
update regarding phone number privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ the Finnish mobile company Jolla Ltd. and the Sailfish OS community.
 - SfOS QML App dev
   - [Telegram](https://t.me/joinchat/Az9rWwlOc_JbRyYH7hxG7Q)
 - [SailfishOS Fan Club on Signal](https://signal.group/#CjQKIAq0Wqusuhku1jYnt0hnGrIMmEVEWyzGxpIotkJkbguREhBZ6qdYOtNwLhXJ-KPoPs1D)
-  - Note that _Signal will share your phone number_ with other group members if [phone number privacy](https://support.signal.org/hc/en-us/articles/6712070553754-Phone-Number-Privacy-and-Usernames) is turned off.
+  - Note that _Signal will share your phone number_ with other group members if
+    [phone number privacy](https://support.signal.org/hc/en-us/articles/6712070553754-Phone-Number-Privacy-and-Usernames)
+    is turned off.
 
 ### In German
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ the Finnish mobile company Jolla Ltd. and the Sailfish OS community.
 - SfOS QML App dev
   - [Telegram](https://t.me/joinchat/Az9rWwlOc_JbRyYH7hxG7Q)
 - [SailfishOS Fan Club on Signal](https://signal.group/#CjQKIAq0Wqusuhku1jYnt0hnGrIMmEVEWyzGxpIotkJkbguREhBZ6qdYOtNwLhXJ-KPoPs1D)
-  - Note that _Signal will share your phone number_ with other group members.
+  - Note that _Signal will share your phone number_ with other group members if [phone number privacy](https://support.signal.org/hc/en-us/articles/6712070553754-Phone-Number-Privacy-and-Usernames) is turned off.
 
 ### In German
 


### PR DESCRIPTION
Signal has not shared phone numbers by default since a year or two, and Whisperfish adopted this default as well. Thought I'd update the note. It might be worth making this a bit less of a scary warning as well, so feel free to update the phrasing!